### PR TITLE
Add basic ListEC2 processor. No tests for now, just manually tested…

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/pom.xml
@@ -54,6 +54,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
         </dependency>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ec2/AbstractEC2Processor.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-abstract-processors/src/main/java/org/apache/nifi/processors/aws/ec2/AbstractEC2Processor.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.ec2;
+
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processors.aws.v2.AbstractAwsProcessor;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
+
+public abstract class AbstractEC2Processor extends AbstractAwsProcessor<Ec2Client, Ec2ClientBuilder> {
+    @Override
+    protected Ec2ClientBuilder createClientBuilder(ProcessContext context) {
+        return Ec2Client.builder();
+    }
+
+}

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -23,7 +23,6 @@
 
     <artifactId>nifi-aws-processors</artifactId>
     <packaging>jar</packaging>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -77,6 +76,17 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ec2</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssm</artifactId>
+            <version>${software.amazon.awssdk.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
@@ -136,10 +146,6 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-textract</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-bundle</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ec2/ListEC2.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ec2/ListEC2.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.ec2;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.processors.aws.v2.AbstractAwsProcessor;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.exception.ProcessException;
+import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.Reservation;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Arrays;
+import java.util.Collections;
+
+@Tags({"Amazon", "EC2", "AWS", "list"})
+@CapabilityDescription("List EC2 instances in a given region. The processor will create a FlowFile for each page of results." +
+        "Use Batch Size to control the number of instances per FlowFile.")
+public class ListEC2 extends AbstractAwsProcessor<Ec2Client, Ec2ClientBuilder> {
+
+    @Override
+    protected Ec2ClientBuilder createClientBuilder(ProcessContext context) {
+        return Ec2Client.builder();
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        final Ec2Client client = getClient(context);
+        String nextToken = null;
+
+        try {
+            do {
+                DescribeInstancesRequest request = DescribeInstancesRequest.builder()
+                        .maxResults(context.getProperty(BATCH_SIZE).asInteger())
+                        .nextToken(nextToken).build();
+                DescribeInstancesResponse response = client.describeInstances(request);
+                final Map<String, String> attributes = new HashMap<>();
+                List<Instance> instances = new ArrayList<Instance>();
+                for (Reservation reservation : response.reservations()) {
+                    instances.addAll(reservation.instances());
+                }
+                if(instances.isEmpty()){
+                    break;
+                }
+                String json = toJson(instances);
+                FlowFile flowFile = session.create();
+                session.write(flowFile, (outputStream) -> {
+                    outputStream.write(json.getBytes());
+                });
+                session.transfer(flowFile, REL_SUCCESS);
+                nextToken = response.nextToken();
+            } while (nextToken != null);
+        } catch (Ec2Exception e) {
+            getLogger().error("Failed to list EC2 instances due to {}", new Object[]{e});
+            context.yield();
+        }
+
+    }
+
+    // convert list of EC2 Instances to JSON
+    private String toJson(List<Instance> instances) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(instances);
+    }
+
+    public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+            .name("Batch Size")
+            .description("The maximum number of functions to return in a single FlowFile. This value must be between 1 and 100." +
+                    "Default value is 10.")
+            .required(true)
+            .addValidator(StandardValidators.createLongValidator(1L, 100L, true))
+            .defaultValue("10")
+            .build();
+
+    public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
+            Arrays.asList(ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE,TIMEOUT,
+                    AWS_CREDENTIALS_PROVIDER_SERVICE, REGION, BATCH_SIZE));
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return Collections.singleton(REL_SUCCESS);
+    }
+}
+
+

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ec2/ListEC2Instances.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ec2/ListEC2Instances.java
@@ -23,12 +23,10 @@ import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.processor.util.StandardValidators;
-import org.apache.nifi.processors.aws.v2.AbstractAwsProcessor;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import software.amazon.awssdk.services.ec2.Ec2ClientBuilder;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
 import software.amazon.awssdk.services.ec2.model.Ec2Exception;
@@ -46,12 +44,7 @@ import java.util.Collections;
 @Tags({"Amazon", "EC2", "AWS", "list"})
 @CapabilityDescription("List EC2 instances in a given region. The processor will create a FlowFile for each page of results." +
         "Use Batch Size to control the number of instances per FlowFile.")
-public class ListEC2 extends AbstractAwsProcessor<Ec2Client, Ec2ClientBuilder> {
-
-    @Override
-    protected Ec2ClientBuilder createClientBuilder(ProcessContext context) {
-        return Ec2Client.builder();
-    }
+public class ListEC2Instances extends AbstractEC2Processor {
 
     @Override
     public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
@@ -104,7 +97,8 @@ public class ListEC2 extends AbstractAwsProcessor<Ec2Client, Ec2ClientBuilder> {
 
     public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
             Arrays.asList(ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE,TIMEOUT,
-                    AWS_CREDENTIALS_PROVIDER_SERVICE, REGION, BATCH_SIZE));
+                    AWS_CREDENTIALS_PROVIDER_SERVICE, REGION, BATCH_SIZE, PROXY_HOST, PROXY_HOST_PORT,
+                    PROXY_USERNAME, PROXY_PASSWORD));
 
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ec2/ListEC2Regions.java
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/java/org/apache/nifi/processors/aws/ec2/ListEC2Regions.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.processors.aws.ec2;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.processor.ProcessContext;
+import org.apache.nifi.processor.ProcessSession;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.processor.exception.ProcessException;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeRegionsRequest;
+import software.amazon.awssdk.services.ec2.model.DescribeRegionsResponse;
+import software.amazon.awssdk.services.ec2.model.Region;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+@Tags({"Amazon", "EC2", "AWS", "list"})
+@CapabilityDescription("List EC2 regions visible to the user. " +
+        "The processor will create a single FlowFile with the list of regions as JSON.")
+public class ListEC2Regions extends AbstractEC2Processor {
+
+    public static final List<PropertyDescriptor> properties = Collections.unmodifiableList(
+            Arrays.asList(ACCESS_KEY, SECRET_KEY, CREDENTIALS_FILE, REGION, TIMEOUT,
+                    AWS_CREDENTIALS_PROVIDER_SERVICE, PROXY_HOST, PROXY_HOST_PORT,
+                    PROXY_USERNAME, PROXY_PASSWORD));
+
+    @Override
+    protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return properties;
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return Collections.singleton(REL_SUCCESS);
+    }
+
+    @Override
+    public void onTrigger(ProcessContext context, ProcessSession session) throws ProcessException {
+        // Fetch the list of regions
+        final Ec2Client client = getClient(context);
+        DescribeRegionsRequest request = DescribeRegionsRequest.builder().build();
+        DescribeRegionsResponse response = client.describeRegions(request);
+        List<Region> regions = response.regions();
+
+        // Write the results to an output flowfile
+        if(!regions.isEmpty()){
+            String json = toJson(regions);
+            FlowFile flowFile = session.create();
+            session.write(flowFile, (outputStream) -> {
+                outputStream.write(json.getBytes());
+            });
+            session.transfer(flowFile, REL_SUCCESS);
+        }
+    }
+
+    //Convert list of regions to JSON using GSON
+    private String toJson(List<Region> regions) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(regions);
+    }
+}

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+org.apache.nifi.processors.aws.ec2.ListEC2
 org.apache.nifi.processors.aws.s3.FetchS3Object
 org.apache.nifi.processors.aws.s3.PutS3Object
 org.apache.nifi.processors.aws.s3.DeleteS3Object

--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-org.apache.nifi.processors.aws.ec2.ListEC2
+org.apache.nifi.processors.aws.ec2.ListEC2Instances
+org.apache.nifi.processors.aws.ec2.ListEC2Regions
 org.apache.nifi.processors.aws.s3.FetchS3Object
 org.apache.nifi.processors.aws.s3.PutS3Object
 org.apache.nifi.processors.aws.s3.DeleteS3Object


### PR DESCRIPTION
# Summary

Created a very basic ListEC2 processor that returns all EC2 instances in JSON format

# Testing
Unit and integration tests to follow, but for now this is only tested manually
