### PR TITLE
ANE-258: new features for GetSMBAccountPermissions processor

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -18,8 +18,12 @@ name: ci-workflow
 on: [push, pull_request]
 
 env:
-  MAVEN_COMMAND: ./mvnw
-  MAVEN_COMMAND_WINDOWS: ./mvnw.cmd
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  AWS_DOMAIN_OWNER: ${{ secrets.AWS_DOMAIN_OWNER }}
+  MAVEN_COMMAND: ./mvnw --settings .github/workflows/maven-settings.xml
+  MAVEN_COMMAND_WINDOWS: ./mvnw.cmd --settings .github/workflows/maven-settings.xml
   DEFAULT_MAVEN_OPTS: >-
     -Xmx3g
     -XX:ReservedCodeCacheSize=1g
@@ -91,6 +95,7 @@ permissions:
 
 jobs:
   static-analysis:
+    environment: anetac-edge
     timeout-minutes: 30
     name: Static Analysis
     runs-on: ubuntu-latest
@@ -120,6 +125,7 @@ jobs:
           -P include-grpc
 
   ubuntu-build-en:
+    environment: anetac-edge
     timeout-minutes: 120
     runs-on: ubuntu-latest
     name: Ubuntu Zulu JDK 17 EN
@@ -183,6 +189,7 @@ jobs:
         run: df
 
   macos-build-jdk-17:
+    environment: anetac-edge
     timeout-minutes: 150
     runs-on: macos-latest
     name: MacOS Temurin JDK 17

--- a/.github/workflows/maven-settings.xml
+++ b/.github/workflows/maven-settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+<servers>
+        <server>
+            <id>codeartifact</id>
+            <username>aws</username>
+            <password>${env.CODEARTIFACT_AUTH_TOKEN}</password>
+        </server>
+    </servers>
+
+
+</settings>

--- a/mvnw
+++ b/mvnw
@@ -235,5 +235,7 @@ fi
 printf %s\\n "$distributionUrl" > "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
 mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
+export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain anetac --domain-owner $AWS_DOMAIN_OWNER --region $AWS_DEFAULT_REGION --query authorizationToken --output text`
+
 clean || :
 exec_maven "$@"

--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/pom.xml
@@ -98,5 +98,9 @@
             <artifactId>nifi-distributed-cache-client-service-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-smb-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-smb-bundle/pom.xml
@@ -15,7 +15,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
+    <repositories>
+        <repository>
+            <id>codeartifact</id>
+            <url>https://anetac-871494285324.d.codeartifact.us-east-1.amazonaws.com/maven/maven/</url>
+        </repository>
+    </repositories>
     <parent>
         <groupId>org.apache.nifi</groupId>
         <artifactId>nifi-nar-bundles</artifactId>


### PR DESCRIPTION
New features for Anetac AD connectors (related to ANE-260, ANE-:
    * add option to customize the name of the attribute to which permissions are written
    * add option to customize the delimiter symbol (defaults to ";")
