### PR TITLE
ANE-244: Add ability to provide multiple SID fields and lookup parent groups

### DIFF
--- a/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/EnumerateAccountRights.java
+++ b/nifi-nar-bundles/nifi-smb-bundle/nifi-smb-processors/src/main/java/org/apache/nifi/processors/smb/EnumerateAccountRights.java
@@ -115,7 +115,7 @@ public class EnumerateAccountRights extends AbstractProcessor {
 
     public static final PropertyDescriptor SID_FIELD_NAME = new PropertyDescriptor.Builder()
             .name("SID field name")
-            .description("Name of record field that contains Active Directory SID. Can be a coma separated list of fields.")
+            .description("Name of record field that contains Active Directory SID. Can be a comma separated list of fields.")
             .required(true)
             .defaultValue("objectSid")
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)


### PR DESCRIPTION
Fixes #ANE-244
Added new features:
* `SID field names` property can now be a coma-separated list of fields. This allows looking up permissions for `objectSid` as well as primary group in a single call
* Added `MemberOf field name` property to indicate where the processor can find parent groups
* Processor looks up SIDs for parent groups and adds permissions for parent groups into the output