### PR TITLE
ANE-398: add ability to assign SSL context service to registry client…

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/CommandOption.java
@@ -78,6 +78,8 @@ public enum CommandOption {
     REGISTRY_CLIENT_URL("rcu", "registryClientUrl", "The url of the registry client", true),
     REGISTRY_CLIENT_DESC("rcd", "registryClientDesc", "The description of the registry client", true),
 
+    SSL_CONTEXT_SERVICE_ID("ssl", "sslContextServiceId", "The ID of SSL Context Service", true),
+
     // NiFi - PGs
     PG_ID("pgid", "processGroupId", "The id of a process group", true),
     PG_NAME("pgn", "processGroupName", "The name of a process group", true),

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGImport.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGImport.java
@@ -66,6 +66,7 @@ public class PGImport extends AbstractNiFiCommand<StringResult> {
         addOption(CommandOption.POS_X.createOption());
         addOption(CommandOption.POS_Y.createOption());
         addOption(CommandOption.KEEP_EXISTING_PARAMETER_CONTEXT.createOption());
+        addOption(CommandOption.PG_NAME.createOption());
     }
 
     @Override
@@ -75,6 +76,7 @@ public class PGImport extends AbstractNiFiCommand<StringResult> {
         final String bucketId = getRequiredArg(properties, CommandOption.BUCKET_ID);
         final String flowId = getRequiredArg(properties, CommandOption.FLOW_ID);
         final Integer flowVersion = getRequiredIntArg(properties, CommandOption.FLOW_VERSION);
+        final String name = getArg(properties, CommandOption.PG_NAME);
 
         final String posXStr = getArg(properties, CommandOption.POS_X);
         final String posYStr = getArg(properties, CommandOption.POS_Y);
@@ -143,6 +145,9 @@ public class PGImport extends AbstractNiFiCommand<StringResult> {
         final ProcessGroupDTO pgDto = new ProcessGroupDTO();
         pgDto.setVersionControlInformation(versionControlInfo);
         pgDto.setPosition(posDto);
+        if(StringUtils.isNotBlank(name)) {
+            pgDto.setName(name);
+        }
 
         final ProcessGroupEntity pgEntity = new ProcessGroupEntity();
         pgEntity.setComponent(pgDto);
@@ -150,6 +155,11 @@ public class PGImport extends AbstractNiFiCommand<StringResult> {
 
         final ProcessGroupClient pgClient = client.getProcessGroupClient();
         final ProcessGroupEntity createdEntity = pgClient.createProcessGroup(parentPgId, pgEntity, Boolean.parseBoolean(keepExistingPC));
+        if(StringUtils.isNotBlank(name)) {
+            createdEntity.getComponent().setName(name);
+            pgClient.updateProcessGroup(createdEntity);
+        }
+
         return new StringResult(createdEntity.getId(), getContext().isInteractive());
     }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/UpdateRegistryClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/registry/UpdateRegistryClient.java
@@ -29,6 +29,8 @@ import org.apache.nifi.toolkit.cli.impl.result.VoidResult;
 import org.apache.nifi.web.api.entity.FlowRegistryClientEntity;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -51,6 +53,7 @@ public class UpdateRegistryClient extends AbstractNiFiCommand<VoidResult> {
         addOption(CommandOption.REGISTRY_CLIENT_NAME.createOption());
         addOption(CommandOption.REGISTRY_CLIENT_URL.createOption());
         addOption(CommandOption.REGISTRY_CLIENT_DESC.createOption());
+        addOption(CommandOption.SSL_CONTEXT_SERVICE_ID.createOption());
     }
 
     @Override
@@ -69,6 +72,7 @@ public class UpdateRegistryClient extends AbstractNiFiCommand<VoidResult> {
         final String name = getArg(properties, CommandOption.REGISTRY_CLIENT_NAME);
         final String url = getArg(properties, CommandOption.REGISTRY_CLIENT_URL);
         final String desc = getArg(properties, CommandOption.REGISTRY_CLIENT_DESC);
+        final String sslServiceId = getArg(properties, CommandOption.SSL_CONTEXT_SERVICE_ID);
 
         if (StringUtils.isBlank(name) && StringUtils.isBlank(url) && StringUtils.isBlank(desc)) {
             throw new CommandException("Name, url, and desc were all blank, nothing to update");
@@ -78,12 +82,22 @@ public class UpdateRegistryClient extends AbstractNiFiCommand<VoidResult> {
             existingRegClient.getComponent().setName(name);
         }
 
-//        if (StringUtils.isNotBlank(url)) {
-//            existingRegClient.getComponent().setUri(url);
-//        }
+        if (StringUtils.isNotBlank(url)) {
+            existingRegClient.getComponent().setUri(url);
+        }
 
         if (StringUtils.isNotBlank(desc)) {
             existingRegClient.getComponent().setDescription(desc);
+        }
+
+        if (StringUtils.isNotBlank(sslServiceId)) {
+            final Map<String, String> updatedProperties = new HashMap<>();
+            if (existingRegClient.getComponent().getProperties() != null) {
+                updatedProperties.putAll(existingRegClient.getComponent().getProperties());
+            }
+
+            updatedProperties.put("ssl-context-service", sslServiceId);
+            existingRegClient.getComponent().setProperties(updatedProperties);
         }
 
         final String clientId = getContext().getSession().getNiFiClientID();


### PR DESCRIPTION
For some reason, Nifi toolkit does not allow assigning SSL Context service to Registry Client, but we need this feature in order to configure registry clients remotely, so implement it.