### PR TITLE
ANE-478: add json_brief option to nifi toolkit output

### DIFF
--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/api/ResultType.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/api/ResultType.java
@@ -19,6 +19,7 @@ package org.apache.nifi.toolkit.cli.api;
 public enum ResultType {
 
     SIMPLE,
-    JSON;
+    JSON,
+    JSON_BRIEF;
 
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/AbstractWritableResult.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/result/AbstractWritableResult.java
@@ -42,6 +42,8 @@ public abstract class AbstractWritableResult<T> implements WritableResult<T> {
     public void write(final PrintStream output) throws IOException {
         if (resultType == ResultType.JSON) {
             writeJsonResult(output);
+        } else if (resultType == ResultType.JSON_BRIEF) {
+            writeBriefJsonResult(output);
         } else {
             writeSimpleResult(output);
         }
@@ -54,4 +56,7 @@ public abstract class AbstractWritableResult<T> implements WritableResult<T> {
         JacksonUtils.write(getResult(), output);
     }
 
+    protected void writeBriefJsonResult(PrintStream output) throws IOException {
+        JacksonUtils.writeBrief(getResult(), output);
+    }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/JacksonUtils.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/JacksonUtils.java
@@ -16,23 +16,41 @@
  */
 package org.apache.nifi.toolkit.cli.impl.util;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import org.apache.nifi.web.api.dto.ComponentDTO;
+import org.apache.nifi.web.api.dto.ControllerServiceDTO;
+import org.apache.nifi.web.api.dto.ParameterContextDTO;
+import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
+import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
+import org.apache.nifi.web.api.entity.ControllerServiceReferencingComponentEntity;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
+import java.util.Set;
 
 public class JacksonUtils {
+
+    public abstract class ProcessorConfigMixin {
+        @JsonIgnore private Map<String, PropertyDescriptorDTO> descriptors;
+        @JsonIgnore private Set<ControllerServiceReferencingComponentEntity> referencingComponents;
+    }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     static {
         MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         MAPPER.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
-        MAPPER.setAnnotationIntrospector(new JaxbAnnotationIntrospector(MAPPER.getTypeFactory()));
+        //MAPPER.setAnnotationIntrospector(new JaxbAnnotationIntrospector(MAPPER.getTypeFactory()));
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        MAPPER.addMixIn(Object.class, ProcessorConfigMixin.class);
+        MAPPER.addMixIn(ComponentDTO.class, ProcessorConfigMixin.class);
+        MAPPER.addMixIn(ControllerServiceDTO.class, ProcessorConfigMixin.class);
+        MAPPER.addMixIn(ProcessorConfigDTO.class, ProcessorConfigMixin.class);
+        MAPPER.addMixIn(ParameterContextDTO.class, ProcessorConfigMixin.class);
     }
 
     private static final ObjectWriter OBJECT_WRITER = MAPPER.writerWithDefaultPrettyPrinter();

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/JacksonUtils.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/util/JacksonUtils.java
@@ -21,12 +21,17 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import org.apache.nifi.web.api.dto.ComponentDTO;
 import org.apache.nifi.web.api.dto.ControllerServiceDTO;
 import org.apache.nifi.web.api.dto.ParameterContextDTO;
+import org.apache.nifi.web.api.dto.ParameterDTO;
 import org.apache.nifi.web.api.dto.ProcessorConfigDTO;
 import org.apache.nifi.web.api.dto.PropertyDescriptorDTO;
+import org.apache.nifi.web.api.entity.AffectedComponentEntity;
 import org.apache.nifi.web.api.entity.ControllerServiceReferencingComponentEntity;
+import org.apache.nifi.web.api.entity.ParameterContextReferenceEntity;
+import org.apache.nifi.web.api.entity.ProcessGroupEntity;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -35,36 +40,56 @@ import java.util.Set;
 
 public class JacksonUtils {
 
-    public abstract class ProcessorConfigMixin {
+    public abstract class ProcessorMixin {
         @JsonIgnore private Map<String, PropertyDescriptorDTO> descriptors;
         @JsonIgnore private Set<ControllerServiceReferencingComponentEntity> referencingComponents;
+        @JsonIgnore private ParameterContextReferenceEntity parameterContext;
+        @JsonIgnore private Set<ProcessGroupEntity> boundProcessGroups;
     }
 
+    public abstract class ParamMixin {
+        @JsonIgnore private Map<String, PropertyDescriptorDTO> descriptors;
+        @JsonIgnore private Set<AffectedComponentEntity> referencingComponents;
+        @JsonIgnore private ParameterContextReferenceEntity parameterContext;
+    }
+
+    private static final ObjectMapper BRIEF_MAPPER = new ObjectMapper();
     private static final ObjectMapper MAPPER = new ObjectMapper();
     static {
         MAPPER.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         MAPPER.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL));
-        //MAPPER.setAnnotationIntrospector(new JaxbAnnotationIntrospector(MAPPER.getTypeFactory()));
+        MAPPER.setAnnotationIntrospector(new JaxbAnnotationIntrospector(MAPPER.getTypeFactory()));
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        MAPPER.addMixIn(Object.class, ProcessorConfigMixin.class);
-        MAPPER.addMixIn(ComponentDTO.class, ProcessorConfigMixin.class);
-        MAPPER.addMixIn(ControllerServiceDTO.class, ProcessorConfigMixin.class);
-        MAPPER.addMixIn(ProcessorConfigDTO.class, ProcessorConfigMixin.class);
-        MAPPER.addMixIn(ParameterContextDTO.class, ProcessorConfigMixin.class);
+
+        BRIEF_MAPPER.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        BRIEF_MAPPER.setDefaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_EMPTY, JsonInclude.Include.NON_EMPTY));
+        BRIEF_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        BRIEF_MAPPER.addMixIn(ComponentDTO.class, ProcessorMixin.class);
+        BRIEF_MAPPER.addMixIn(ControllerServiceDTO.class, ProcessorMixin.class);
+        BRIEF_MAPPER.addMixIn(ProcessorConfigDTO.class, ProcessorMixin.class);
+        BRIEF_MAPPER.addMixIn(ParameterContextDTO.class, ProcessorMixin.class);
+        BRIEF_MAPPER.addMixIn(ParameterDTO.class, ParamMixin.class);
     }
 
     private static final ObjectWriter OBJECT_WRITER = MAPPER.writerWithDefaultPrettyPrinter();
+    private static final ObjectWriter BRIEF_BJECT_WRITER = BRIEF_MAPPER.writerWithDefaultPrettyPrinter();
 
     public static ObjectMapper getObjectMapper() {
         return MAPPER;
+    }
+    public static ObjectMapper getBriefObjectMapper() {
+        return BRIEF_MAPPER;
     }
 
     public static ObjectWriter getObjectWriter() {
         return OBJECT_WRITER;
     }
+    public static ObjectWriter getBriefObjectWriter() {
+        return BRIEF_BJECT_WRITER;
+    }
 
-    public static void write(final Object result, final OutputStream output) throws IOException {
-        OBJECT_WRITER.writeValue(new OutputStream() {
+    public static void write(final Object result, final OutputStream output, ObjectWriter writer) throws IOException {
+        writer.writeValue(new OutputStream() {
             @Override
             public void write(byte[] b) throws IOException {
                 output.write(b);
@@ -86,5 +111,12 @@ public class JacksonUtils {
                 output.flush();
             }
         }, result);
+    }
+    public static void write(final Object result, final OutputStream output) throws IOException {
+        write(result, output, OBJECT_WRITER);
+    }
+
+    public static void writeBrief(final Object result, final OutputStream output) throws IOException {
+        write(result, output, BRIEF_BJECT_WRITER);
     }
 }


### PR DESCRIPTION
we don't need referencing components or descriptors in the toolkit output