### PR TITLE
ANE-511: remove aws-java-sdk-bundle from the build

### DIFF
--- a/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml
@@ -149,10 +149,6 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-bundle</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
remove `aws-java-sdk-bundle` from `nifi-nar-bundles/nifi-aws-bundle/nifi-aws-processors/pom.xml` to avoid `java.lang.NoSuchMethodError: 'com.amazonaws.thirdparty.jackson.core.JsonToken com.amazonaws.transform.JsonUnmarshallerContext.getCurrentToken()'` when trying to write DynamoDB with PutDynamoDB processor