### PR TITLE
ANE-936: add delete-user commands to nifi and registry toolkits

### DIFF
--- a/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
@@ -99,6 +99,7 @@ The following are available commands:
  nifi pg-get-param-context
  nifi pg-set-param-context
  nifi pg-replace
+ nifi pg-delete
  nifi get-services
  nifi get-service
  nifi create-service

--- a/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
+++ b/nifi-docs/src/main/asciidoc/toolkit-guide.adoc
@@ -112,6 +112,7 @@ The following are available commands:
  nifi stop-reporting-tasks
  nifi list-users
  nifi create-user
+ nifi delete-user
  nifi list-user-groups
  nifi create-user-group
  nifi update-user-group
@@ -166,6 +167,7 @@ The following are available commands:
  registry list-extensions
  registry list-users
  registry create-user
+ registry delete-user
  registry update-user
  registry list-user-groups
  registry create-user-group
@@ -316,7 +318,7 @@ Typing "nifi " and then a tab will show the sub-commands for NiFi:
  delete-param-context    get-services            pg-get-services         update-user-group
  disable-services        import-param-context    pg-get-vars             upload-template
  disconnect-node         list-param-contexts     pg-get-version          delete-reporting-task
- download-template       list-reg-clients        pg-import
+ download-template       list-reg-clients        pg-import               delete-user
 
 Arguments that represent a path to a file, such as `-p` or when setting a properties file in the session, will auto-complete the path being typed:
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/ProcessGroupClient.java
@@ -75,4 +75,6 @@ public interface ProcessGroupClient {
         throws NiFiClientException, IOException;
 
     FlowComparisonEntity getLocalModifications(String processGroupId) throws NiFiClientException, IOException;
+
+    void deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException;
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/TenantsClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/TenantsClient.java
@@ -27,7 +27,11 @@ public interface TenantsClient {
 
     UsersEntity getUsers() throws NiFiClientException, IOException;
 
+    UserEntity getUser(String userId) throws NiFiClientException, IOException;
+
     UserEntity createUser(UserEntity userEntity) throws NiFiClientException, IOException;
+
+    UserEntity deleteUser(UserEntity userEntity) throws NiFiClientException, IOException;
 
     UserGroupEntity getUserGroup(String userGroupId) throws NiFiClientException, IOException;
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessGroupClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyProcessGroupClient.java
@@ -356,4 +356,21 @@ public class JerseyProcessGroupClient extends AbstractJerseyClient implements Pr
         });
     }
 
+    @Override
+    public void deleteProcessGroup(ProcessGroupEntity entity) throws NiFiClientException, IOException {
+        if (entity == null) {
+            throw new IllegalArgumentException("Process group entity cannot be null");
+        }
+
+        executeAction("Error deleting process group", () -> {
+            final WebTarget target = processGroupsTarget
+                    .path("{id}")
+                    .queryParam("version", entity.getRevision().getVersion())
+                    .resolveTemplate("id", entity.getId());
+
+            getRequestBuilder(target).delete();
+            return null;
+        });
+    }
+
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyTenantsClient.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/client/nifi/impl/JerseyTenantsClient.java
@@ -55,6 +55,20 @@ public class JerseyTenantsClient extends AbstractJerseyClient implements Tenants
     }
 
     @Override
+    public UserEntity getUser(String userId) throws NiFiClientException, IOException {
+        if (StringUtils.isBlank(userId)) {
+            throw new IllegalArgumentException("User id cannot be null");
+        }
+
+        return executeAction("Error retrieving user", () -> {
+            final WebTarget target = tenantsTarget
+                    .path("users/{id}")
+                    .resolveTemplate("id", userId);
+            return getRequestBuilder(target).get(UserEntity.class);
+        });
+    }
+
+    @Override
     public UserEntity createUser(final UserEntity userEntity) throws NiFiClientException, IOException {
         if (userEntity == null) {
             throw new IllegalArgumentException("User entity cannot be null");
@@ -67,6 +81,21 @@ public class JerseyTenantsClient extends AbstractJerseyClient implements Tenants
                     Entity.entity(userEntity, MediaType.APPLICATION_JSON),
                     UserEntity.class
             );
+        });
+    }
+
+    @Override
+    public UserEntity deleteUser(final UserEntity userEntity) throws NiFiClientException, IOException {
+        if (StringUtils.isBlank(userEntity.getId())) {
+            throw new IllegalArgumentException("User id cannot be null");
+        }
+
+        return executeAction("Error deleting user", () -> {
+            final WebTarget target = tenantsTarget
+                    .path("users/{id}")
+                    .queryParam("version", userEntity.getRevision().getVersion())
+                    .resolveTemplate("id", userEntity.getId());
+            return getRequestBuilder(target).delete(UserEntity.class);
         });
     }
 

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
@@ -90,6 +90,7 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.templates.ListTemplates;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.templates.UploadTemplate;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.tenants.CreateUser;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.tenants.CreateUserGroup;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.tenants.DeleteUser;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.tenants.ListUserGroups;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.tenants.ListUsers;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.tenants.UpdateUserGroup;
@@ -156,6 +157,7 @@ public class NiFiCommandGroup extends AbstractCommandGroup {
         commands.add(new StopReportingTasks());
         commands.add(new ListUsers());
         commands.add(new CreateUser());
+        commands.add(new DeleteUser());
         commands.add(new ListUserGroups());
         commands.add(new CreateUserGroup());
         commands.add(new UpdateUserGroup());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/NiFiCommandGroup.java
@@ -62,6 +62,7 @@ import org.apache.nifi.toolkit.cli.impl.command.nifi.params.SetParamProviderProp
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGChangeVersion;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGCreate;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGCreateControllerService;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGDelete;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGDisableControllerServices;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGEnableControllerServices;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.pg.PGGetAllVersions;
@@ -144,6 +145,7 @@ public class NiFiCommandGroup extends AbstractCommandGroup {
         commands.add(new PGGetParamContext());
         commands.add(new PGSetParamContext());
         commands.add(new PGReplace());
+        commands.add(new PGDelete());
         commands.add(new GetControllerServices());
         commands.add(new GetControllerService());
         commands.add(new CreateControllerService());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/pg/PGDelete.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.nifi.pg;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.ProcessGroupClient;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.VoidResult;
+import org.apache.nifi.web.api.entity.ProcessGroupEntity;
+
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Command to delete a process group.
+ */
+public class PGDelete extends AbstractNiFiCommand<VoidResult> {
+
+        public PGDelete() {
+            super("pg-delete", VoidResult.class);
+        }
+
+        @Override
+        public String getDescription() {
+            return "Deletes the given process group.";
+        }
+
+        @Override
+        protected void doInitialize(final Context context) {
+            addOption(CommandOption.PG_ID.createOption());
+        }
+
+        @Override
+        public VoidResult doExecute(final NiFiClient client, final Properties properties)
+                throws NiFiClientException, IOException, MissingOptionException {
+
+            final String pgId = getRequiredArg(properties, CommandOption.PG_ID);
+
+            final ProcessGroupClient pgClient = client.getProcessGroupClient();
+            final ProcessGroupEntity pgEntity = pgClient.getProcessGroup(pgId);
+            if(pgEntity == null) {
+                throw new NiFiClientException("Process group with id " + pgId + " not found.");
+            }
+            pgClient.deleteProcessGroup(pgEntity);
+
+            return new VoidResult();
+        }
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/tenants/DeleteUser.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/tenants/DeleteUser.java
@@ -23,17 +23,19 @@ import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
 import org.apache.nifi.toolkit.cli.impl.client.nifi.TenantsClient;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
-import org.apache.nifi.toolkit.cli.impl.result.StringResult;
-import org.apache.nifi.web.api.dto.UserDTO;
+import org.apache.nifi.toolkit.cli.impl.result.VoidResult;
 import org.apache.nifi.web.api.entity.UserEntity;
 
 import java.io.IOException;
 import java.util.Properties;
 
-public class DeleteUser extends AbstractNiFiCommand<StringResult> {
+/**
+ * Command to delete a Nifi user.
+ */
+public class DeleteUser extends AbstractNiFiCommand<VoidResult> {
 
         public DeleteUser() {
-            super("delete-user", StringResult.class);
+            super("delete-user", VoidResult.class);
         }
 
         @Override
@@ -47,7 +49,7 @@ public class DeleteUser extends AbstractNiFiCommand<StringResult> {
         }
 
         @Override
-        public StringResult doExecute(final NiFiClient client, final Properties properties)
+        public VoidResult doExecute(final NiFiClient client, final Properties properties)
                 throws NiFiClientException, IOException, MissingOptionException {
 
             final String userId = getRequiredArg(properties, CommandOption.USER_ID);
@@ -57,6 +59,6 @@ public class DeleteUser extends AbstractNiFiCommand<StringResult> {
             }
             final TenantsClient tenantsClient = client.getTenantsClient();
             tenantsClient.deleteUser(userEntity);
-            return new StringResult(userId, getContext().isInteractive());
+            return new VoidResult();
         }
 }

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/tenants/DeleteUser.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/tenants/DeleteUser.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.nifi.toolkit.cli.impl.command.nifi.tenants;
 
 import org.apache.commons.cli.MissingOptionException;

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/tenants/DeleteUser.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/nifi/tenants/DeleteUser.java
@@ -1,0 +1,46 @@
+package org.apache.nifi.toolkit.cli.impl.command.nifi.tenants;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClient;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.NiFiClientException;
+import org.apache.nifi.toolkit.cli.impl.client.nifi.TenantsClient;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.nifi.AbstractNiFiCommand;
+import org.apache.nifi.toolkit.cli.impl.result.StringResult;
+import org.apache.nifi.web.api.dto.UserDTO;
+import org.apache.nifi.web.api.entity.UserEntity;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class DeleteUser extends AbstractNiFiCommand<StringResult> {
+
+        public DeleteUser() {
+            super("delete-user", StringResult.class);
+        }
+
+        @Override
+        public String getDescription() {
+            return "Deletes the user with the given id.";
+        }
+
+        @Override
+        protected void doInitialize(final Context context) {
+            addOption(CommandOption.USER_ID.createOption());
+        }
+
+        @Override
+        public StringResult doExecute(final NiFiClient client, final Properties properties)
+                throws NiFiClientException, IOException, MissingOptionException {
+
+            final String userId = getRequiredArg(properties, CommandOption.USER_ID);
+            UserEntity userEntity = client.getTenantsClient().getUser(userId);
+            if (userEntity == null) {
+                throw new NiFiClientException("User with id " + userId + " does not exist");
+            }
+            final TenantsClient tenantsClient = client.getTenantsClient();
+            tenantsClient.deleteUser(userEntity);
+            return new StringResult(userId, getContext().isInteractive());
+        }
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/NiFiRegistryCommandGroup.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/NiFiRegistryCommandGroup.java
@@ -49,6 +49,7 @@ import org.apache.nifi.toolkit.cli.impl.command.registry.policy.GetAccessPolicy;
 import org.apache.nifi.toolkit.cli.impl.command.registry.tenant.CreateUser;
 import org.apache.nifi.toolkit.cli.impl.command.registry.tenant.CreateUserGroup;
 import org.apache.nifi.toolkit.cli.impl.command.registry.policy.CreateOrUpdateAccessPolicy;
+import org.apache.nifi.toolkit.cli.impl.command.registry.tenant.DeleteUser;
 import org.apache.nifi.toolkit.cli.impl.command.registry.tenant.ListUserGroups;
 import org.apache.nifi.toolkit.cli.impl.command.registry.tenant.ListUsers;
 import org.apache.nifi.toolkit.cli.impl.command.registry.tenant.UpdateUser;
@@ -96,6 +97,7 @@ public class NiFiRegistryCommandGroup extends AbstractCommandGroup {
         commandList.add(new ListExtensions());
         commandList.add(new ListUsers());
         commandList.add(new CreateUser());
+        commandList.add(new DeleteUser());
         commandList.add(new UpdateUser());
         commandList.add(new ListUserGroups());
         commandList.add(new CreateUserGroup());

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/tenant/DeleteUser.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/tenant/DeleteUser.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.toolkit.cli.impl.command.registry.tenant;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.nifi.registry.authorization.User;
+import org.apache.nifi.registry.client.NiFiRegistryClient;
+import org.apache.nifi.registry.client.NiFiRegistryException;
+import org.apache.nifi.registry.client.TenantsClient;
+import org.apache.nifi.toolkit.cli.api.Context;
+import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
+import org.apache.nifi.toolkit.cli.impl.command.registry.AbstractNiFiRegistryCommand;
+import org.apache.nifi.toolkit.cli.impl.result.StringResult;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class DeleteUser extends AbstractNiFiRegistryCommand<StringResult> {
+
+        public DeleteUser() {
+            super("delete-user", StringResult.class);
+        }
+
+        @Override
+        public String getDescription() {
+            return "Deletes the user with the given id.";
+        }
+
+        @Override
+        protected void doInitialize(final Context context) {
+            addOption(CommandOption.USER_ID.createOption());
+        }
+
+        @Override
+        public StringResult doExecute(final NiFiRegistryClient client, final Properties properties)
+                throws IOException, NiFiRegistryException, ParseException {
+
+            final TenantsClient tenantsClient = client.getTenantsClient();
+
+            final String userId = getRequiredArg(properties, CommandOption.USER_ID);
+            final User user = tenantsClient.getUser(userId);
+            if (user == null) {
+                throw new NiFiRegistryException("User does not exist with id " + userId);
+            }
+
+            tenantsClient.deleteUser(userId);
+
+            return new StringResult(userId, getContext().isInteractive());
+        }
+
+}

--- a/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/tenant/DeleteUser.java
+++ b/nifi-toolkit/nifi-toolkit-cli/src/main/java/org/apache/nifi/toolkit/cli/impl/command/registry/tenant/DeleteUser.java
@@ -24,15 +24,18 @@ import org.apache.nifi.registry.client.TenantsClient;
 import org.apache.nifi.toolkit.cli.api.Context;
 import org.apache.nifi.toolkit.cli.impl.command.CommandOption;
 import org.apache.nifi.toolkit.cli.impl.command.registry.AbstractNiFiRegistryCommand;
-import org.apache.nifi.toolkit.cli.impl.result.StringResult;
+import org.apache.nifi.toolkit.cli.impl.result.VoidResult;
 
 import java.io.IOException;
 import java.util.Properties;
 
-public class DeleteUser extends AbstractNiFiRegistryCommand<StringResult> {
+/**
+ * Command to delete a Nifi Registry user.
+ */
+public class DeleteUser extends AbstractNiFiRegistryCommand<VoidResult> {
 
         public DeleteUser() {
-            super("delete-user", StringResult.class);
+            super("delete-user", VoidResult.class);
         }
 
         @Override
@@ -46,7 +49,7 @@ public class DeleteUser extends AbstractNiFiRegistryCommand<StringResult> {
         }
 
         @Override
-        public StringResult doExecute(final NiFiRegistryClient client, final Properties properties)
+        public VoidResult doExecute(final NiFiRegistryClient client, final Properties properties)
                 throws IOException, NiFiRegistryException, ParseException {
 
             final TenantsClient tenantsClient = client.getTenantsClient();
@@ -59,7 +62,7 @@ public class DeleteUser extends AbstractNiFiRegistryCommand<StringResult> {
 
             tenantsClient.deleteUser(userId);
 
-            return new StringResult(userId, getContext().isInteractive());
+            return new VoidResult();
         }
 
 }


### PR DESCRIPTION
ANE-936: add `nifi delete-user` and `registry delete-user` commands to Toolkit. This PR supports another PR in catena repository. In order to be able to delete users from Nifi and Nifi registry in the same way as they are created, I added two more commands to Nifi Toolkit.
Side note: we should contribute this and other changes I made to Nifi to upstream Nifi eventually, so that we can keep our distro up to date with the stable versions