### PR TITLE
ANE-2999: update spring-security and spring-web versions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -165,7 +165,7 @@ jobs:
           ${{ env.MAVEN_BUILD_PROFILES }}
           ${{ env.MAVEN_PROJECTS }}
       - name: Upload Test Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: surefire-reports-ubuntu-17
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ nb-configuration.xml
 
 .vscode/
 .java-version
+package-lock.json

--- a/anetac-pom.xml
+++ b/anetac-pom.xml
@@ -122,8 +122,8 @@
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <netty.4.version>4.1.95.Final</netty.4.version>
-        <spring.version>5.3.29</spring.version>
-        <spring.security.version>5.8.5</spring.security.version>
+        <spring.version>5.3.39</spring.version>
+        <spring.security.version>5.8.15</spring.security.version>
         <swagger.annotations.version>1.6.11</swagger.annotations.version>
         <h2.version>2.2.220</h2.version>
         <zookeeper.version>3.8.2</zookeeper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
         <netty.3.version>3.10.6.Final</netty.3.version>
         <snakeyaml.version>2.2</snakeyaml.version>
         <netty.4.version>4.1.111.Final</netty.4.version>
-        <spring.version>5.3.37</spring.version>
-        <spring.security.version>5.8.14</spring.security.version>
+        <spring.version>5.3.39</spring.version>
+        <spring.security.version>5.8.15</spring.security.version>
         <swagger.annotations.version>1.6.14</swagger.annotations.version>
         <h2.version>2.2.224</h2.version>
         <zookeeper.version>3.9.2</zookeeper.version>


### PR DESCRIPTION
Update spring-security to 5.8.15
Update spring-web to 5.3.39

Per this page: https://spring.io/security/cve-2024-38821 the CVE is fixed in 5.8.15. The page says 5.8.15 is available for Enterprise Support only, but it appears to be available for OSS. Also, the Maven Central page: https://mvnrepository.com/artifact/org.springframework.security/spring-security-web/5.8.15 does not mention that vulnerability for sprint-security 5.8.15