### PR TITLE
ANE-3997: do not crash EvaluateJsonPath on invalid JSON

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateJsonPath.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/main/java/org/apache/nifi/processors/standard/EvaluateJsonPath.java
@@ -38,6 +38,7 @@ import org.apache.nifi.components.ValidationContext;
 import org.apache.nifi.components.ValidationResult;
 import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.processor.DataUnit;
 import org.apache.nifi.processor.ProcessContext;
@@ -344,6 +345,9 @@ public class EvaluateJsonPath extends AbstractJsonPathProcessor {
                 flowFile = processSession.putAllAttributes(flowFile, jsonPathResults);
             }
             processSession.transfer(flowFile, REL_MATCH);
+        } catch (final Exception e) {
+            logger.error("Error processing FlowFile {} did not have valid JSON content.", flowFile.getAttribute(CoreAttributes.UUID.key()), e);
+            processSession.transfer(flowFile, REL_FAILURE);
         } finally {
             attributeToJsonPathEntrySetQueue.offer(attributeJsonPathEntries);
         }


### PR DESCRIPTION
Catch all exceptions that can be through when attempting to parse incoming JSON file. This should address the problem when flow files get lost after logging exceptions like these:
```
2025-08-26 21:35:06,404 INFO [Cleanup Archive for default] o.a.n.c.repository.FileSystemRepository Successfully deleted 59 files (6.22 MB) from archive
2025-08-26 21:35:06,404 INFO [Cleanup Archive for default] o.a.n.c.repository.FileSystemRepository Archive cleanup completed for container default; will now allow writing to this container. Bytes used = 15.77 GB, bytes free = 4.15 GB, capacity = 19.93 GB
2025-08-26 21:35:06,406 ERROR [Timer-Driven Process Thread-10] o.a.n.p.standard.EvaluateJsonPath EvaluateJsonPath[id=9e64ee18-fa85-3aa2-c39a-eb2c4a26a7c8] Processing halted: yielding [1 sec]
java.lang.NullPointerException: Cannot invoke "com.jayway.jsonpath.DocumentContext.read(com.jayway.jsonpath.JsonPath)" because "documentContext" is null
	at org.apache.nifi.processors.standard.EvaluateJsonPath.onTrigger(EvaluateJsonPath.java:304)
	at org.apache.nifi.processor.AbstractProcessor.onTrigger(AbstractProcessor.java:27)
	at org.apache.nifi.controller.StandardProcessorNode.onTrigger(StandardProcessorNode.java:1361)
	at org.apache.nifi.controller.tasks.ConnectableTask.invoke(ConnectableTask.java:247)
	at org.apache.nifi.controller.scheduling.TimerDrivenSchedulingAgent$1.run(TimerDrivenSchedulingAgent.java:102)
	at org.apache.nifi.engine.FlowEngine$2.run(FlowEngine.java:110)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
2025-08-26 21:35:06,406 WARN [Timer-Driven Process Thread-10] o.a.n.controller.tasks.ConnectableTask Processing halted: uncaught exception in Component [EvaluateJsonPath[id=9e64ee18-fa85-3aa2-c39a-eb2c4a26a7c8]]
java.lang.NullPointerException: Cannot invoke "com.jayway.jsonpath.DocumentContext.read(com.jayway.jsonpath.JsonPath)" because "documentContext" is null
	at org.apache.nifi.processors.standard.EvaluateJsonPath.onTrigger(EvaluateJsonPath.java:304)
	at org.apache.nifi.processor.AbstractProcessor.onTrigger(AbstractProcessor.java:27)
	at org.apache.nifi.controller.StandardProcessorNode.onTrigger(StandardProcessorNode.java:1361)
	at org.apache.nifi.controller.tasks.ConnectableTask.invoke(ConnectableTask.java:247)
	at org.apache.nifi.controller.scheduling.TimerDrivenSchedulingAgent$1.run(TimerDrivenSchedulingAgent.java:102)
	at org.apache.nifi.engine.FlowEngine$2.run(FlowEngine.java:110)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)

```