### PR TITLE
fix: implement shouldAllowReverseDnsLookup() for ZooKeeper 3.9.5 compatibility

### DIFF
--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-state-provider/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/server/ZooKeeperQuorumX509Util.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-state-provider/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/server/ZooKeeperQuorumX509Util.java
@@ -30,4 +30,9 @@ public class ZooKeeperQuorumX509Util extends X509Util {
     protected boolean shouldVerifyClientHostname() {
         return true;
     }
+
+    @Override
+    protected boolean shouldAllowReverseDnsLookup() {
+        return true;
+    }
 }

--- a/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-state-provider/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/server/ZooKeeperServerX509Util.java
+++ b/nifi-framework-bundle/nifi-framework-extensions/nifi-framework-zookeeper-bundle/nifi-framework-zookeeper-state-provider/src/main/java/org/apache/nifi/controller/state/providers/zookeeper/server/ZooKeeperServerX509Util.java
@@ -30,4 +30,9 @@ public class ZooKeeperServerX509Util extends X509Util {
     protected boolean shouldVerifyClientHostname() {
         return true;
     }
+
+    @Override
+    protected boolean shouldAllowReverseDnsLookup() {
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary

- Implement `shouldAllowReverseDnsLookup()` in both `ZooKeeperQuorumX509Util` and `ZooKeeperServerX509Util` to fix Java compilation with ZooKeeper 3.9.5
- ZooKeeper 3.9.5 (bumped from 3.9.4 via PR #575) added this abstract method to `X509Util`

## Test Plan

- [ ] Java compilation passes (no more "does not override abstract method" errors)
- [ ] CI passes on all 4 platforms


Made with [Cursor](https://cursor.com)