### PR TITLE
fix: revert kotlin.version to 2.3.10 for Maven dependency resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <!-- JVM languages and bytecode -->
         <aspectj.version>1.9.25.1</aspectj.version>
         <groovy.version>5.0.5</groovy.version>
-        <kotlin.version>2.3.20</kotlin.version>
+        <kotlin.version>2.3.10</kotlin.version>
 
         <!-- Logging and observability -->
         <log4j2.version>2.25.4</log4j2.version>


### PR DESCRIPTION
## Summary

- Revert `kotlin.version` from 2.3.20 to 2.3.10 (original NiFi 2.8.0 value)
- Kotlin 2.3.20's `kotlin-stdlib-common` has no JAR artifact on Maven Central, causing `nifi-aws-processors` dependency resolution failure

## Test Plan

- [ ] Maven dependency resolution passes for nifi-aws-processors
- [ ] CI ci-workflow passes


Made with [Cursor](https://cursor.com)