### PR TITLE
fix: use kotlin.version property in nifi-aws-bundle pom.xml

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -117,7 +117,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
-                <version>2.3.20</version>
+                <version>${kotlin.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

Replace hardcoded `kotlin-stdlib-common` version `2.3.20` with `${kotlin.version}` property reference in `nifi-aws-bundle/pom.xml`. The dependabot kotlin bump (PR #562) added this hardcoded version which doesn't resolve since `kotlin-stdlib-common` has no JAR artifact for 2.3.x.


Made with [Cursor](https://cursor.com)