### PR TITLE
fix: revert kotlin-stdlib-common to 2.0.21 (last version with JAR)

### DIFF
--- a/nifi-extension-bundles/nifi-aws-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-aws-bundle/pom.xml
@@ -117,7 +117,7 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-common</artifactId>
-                <version>${kotlin.version}</version>
+                <version>2.0.21</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

- Reverts `kotlin-stdlib-common` version in `nifi-aws-bundle/pom.xml` from `${kotlin.version}` (2.3.10) back to hardcoded `2.0.21`
- Starting from Kotlin 2.1.0, `kotlin-stdlib-common` is a POM-only artifact (merged into `kotlin-stdlib`), so no JAR exists for versions >= 2.1.0
- `2.0.21` was the original value in the `rel/nifi-2.8.0` tag and is the last version that publishes a separate JAR artifact
- This fixes the Maven build failure: `Could not find artifact org.jetbrains.kotlin:kotlin-stdlib-common:jar:2.3.10`

## Root Cause

PR #759 changed the hardcoded version to `${kotlin.version}`, but `kotlin.version` is `2.3.10` which has no JAR artifact for `kotlin-stdlib-common`.

## Test plan

- CI should pass the `nifi-aws-processors` module compilation

Made with [Cursor](https://cursor.com)