### PR TITLE
fix: revert nifi-api.version from 2.7.0 to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <node.version>v22.19.0</node.version>
 
         <!-- NiFi build -->
-        <nifi-api.version>2.7.0</nifi-api.version>
+        <nifi-api.version>2.6.0</nifi-api.version>
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->


### PR DESCRIPTION
## Summary

- Reverts `nifi-api.version` from `2.7.0` back to `2.6.0` (the original value from the `rel/nifi-2.8.0` tag)
- `nifi-api:2.7.0` introduced new `CONNECTOR`/`Connector` enum values in `ComponentType` and `Component` enums
- The existing switch expressions in `StandardNiFiServiceFacade.java` (lines 4103 and 6439) don't handle these new values, causing Java compilation errors: "the switch expression does not cover all possible input values"

## Root Cause

Dependabot bumped `nifi-api.version` from `2.6.0` to `2.7.0`, introducing new enum values that the NiFi 2.8.0 codebase doesn't yet support.

## Test plan

- CI should pass the `nifi-web-api` module compilation

Made with [Cursor](https://cursor.com)