### PR TITLE
ANE-4903-more-cve-fixes

### DIFF
--- a/minifi/minifi-bom/pom.xml
+++ b/minifi/minifi-bom/pom.xml
@@ -47,6 +47,26 @@
                 <version>2.8.0-ANETAC</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.21.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.21.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/minifi/minifi-nar-bundles/minifi-framework-bundle/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-framework-bundle/pom.xml
@@ -74,6 +74,26 @@ limitations under the License.
                 <version>2.8.0-ANETAC</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.21.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.21.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/minifi/minifi-nar-bundles/minifi-standard-nar/pom.xml
+++ b/minifi/minifi-nar-bundles/minifi-standard-nar/pom.xml
@@ -40,6 +40,26 @@ limitations under the License.
                 <artifactId>janino</artifactId>
                 <version>3.1.12</version>
             </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.21.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.21.4</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-iceberg-bundle/pom.xml
@@ -57,9 +57,29 @@
             <dependency>
                 <groupId>org.apache.iceberg</groupId>
                 <artifactId>iceberg-bom</artifactId>
-                <version>1.10.1</version>
+                <version>1.11.0</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.21.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.21.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
+++ b/nifi-extension-bundles/nifi-protobuf-bundle/nifi-protobuf-services/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <protobuf.version>4.33.5</protobuf.version>
-        <wire.version>6.2.0</wire.version>
+        <wire.version>6.3.0</wire.version>
     </properties>
 
     <dependencies>

--- a/nifi-extension-bundles/nifi-standard-bundle/pom.xml
+++ b/nifi-extension-bundles/nifi-standard-bundle/pom.xml
@@ -150,6 +150,26 @@
                 <version>0.18.1</version>
             </dependency>
             <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>3.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.21.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.21.4</version>
+            </dependency>
+            <dependency>
                 <groupId>io.krakens</groupId>
                 <artifactId>java-grok</artifactId>
                 <version>0.1.9</version>

--- a/nifi-registry/pom.xml
+++ b/nifi-registry/pom.xml
@@ -35,8 +35,8 @@
         <module>nifi-registry-docker-maven</module>
     </modules>
     <properties>
-        <spring.boot.version>4.0.5</spring.boot.version>
-        <flyway.version>12.3.0</flyway.version>
+        <spring.boot.version>4.0.7</spring.boot.version>
+        <flyway.version>12.8.0</flyway.version>
         <flyway.tests.version>10.0.0</flyway.tests.version>
         <swagger.ui.version>3.12.0</swagger.ui.version>
         <jgit.version>7.6.0.202603022253-r</jgit.version>

--- a/nifi-toolkit/nifi-toolkit-cli/pom.xml
+++ b/nifi-toolkit/nifi-toolkit-cli/pom.xml
@@ -24,7 +24,7 @@
     <description>Tooling to make tls configuration easier</description>
 
     <properties>
-        <jline.version>3.30.9</jline.version>
+        <jline.version>4.2.1</jline.version>
     </properties>
 
     <build>
@@ -105,7 +105,7 @@
         </dependency>
         <dependency>
             <groupId>org.jline</groupId>
-            <artifactId>jline-terminal-jna</artifactId>
+            <artifactId>jline-terminal-jni</artifactId>
             <version>${jline.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <nifi.nar.maven.plugin.version>2.3.0</nifi.nar.maven.plugin.version>
 
         <!-- CSPs SDK -->
-        <software.amazon.awssdk.version>2.42.33</software.amazon.awssdk.version>
+        <software.amazon.awssdk.version>2.46.17</software.amazon.awssdk.version>
         <software.amazon.encryption.s3.version>4.0.1</software.amazon.encryption.s3.version>
         <azure.sdk.bom.version>1.3.6</azure.sdk.bom.version> <!-- when changing this version, also update msal4j to the version that is required by azure-identity -->
 


### PR DESCRIPTION
# Jira Issue
ANE-4903

# Description

Follow-up to #1075 in the ANE-4903 CVE remediation effort. This PR bumps transitive dependencies that still resolved to vulnerable versions after the prior round of fixes, and pins Jackson versions in several bundle POMs where dependency convergence was pulling in older artifacts.

Dependency updates
Area	Change
Root
AWS SDK 2.42.33 → 2.46.17
NiFi Registry
Spring Boot 4.0.5 → 4.0.7, Flyway 12.3.0 → 12.8.0
NiFi Toolkit CLI
JLine 3.30.9 → 4.2.1; switch jline-terminal-jna → jline-terminal-jni (JLine 4.x API)
Protobuf bundle
Wire 6.2.0 → 6.3.0
Iceberg bundle
Iceberg BOM 1.10.1 → 1.11.0
Jackson version pinning
Adds explicit dependencyManagement entries in bundle POMs to force patched Jackson versions across both Jackson 2.x and 3.x coordinates:

com.fasterxml.jackson.core:jackson-core / jackson-databind → 2.21.4
tools.jackson.core:jackson-core / jackson-databind → 3.1.4
Affected modules:

minifi/minifi-bom
minifi/minifi-nar-bundles/minifi-framework-bundle
minifi/minifi-nar-bundles/minifi-standard-nar
nifi-extension-bundles/nifi-standard-bundle
nifi-extension-bundles/nifi-iceberg-bundle
