### PR TITLE
ANE-4928: suppress jline warning with Java 24

### DIFF
--- a/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/cli.sh
+++ b/nifi-toolkit/nifi-toolkit-assembly/src/main/resources/bin/cli.sh
@@ -119,7 +119,8 @@ run() {
    export NIFI_TOOLKIT_HOME="$NIFI_TOOLKIT_HOME"
 
    umask 0077
-   exec "${JAVA}" -cp "${CLASSPATH}" ${JAVA_OPTS} org.apache.nifi.toolkit.cli.CLIMain "$@"
+   # Suppress the warning about illegal reflective access operations with Java 24+
+   exec "${JAVA}" --enable-native-access=ALL-UNNAMED -cp "${CLASSPATH}" ${JAVA_OPTS} org.apache.nifi.toolkit.cli.CLIMain "$@"
 }
 
 


### PR DESCRIPTION
The jline package triggers restricted method warnings in Java 24+

```
/opt/nifi/nifi-toolkit-current$ bin/cli.sh
WARNING: A restricted method in java.lang.foreign.MemorySegment has been called
WARNING: java.lang.foreign.MemorySegment::reinterpret has been called by org.jline.terminal.impl.ffm.FfmTerminalProvider in an unnamed module (file:/opt/nifi/nifi-toolkit-current/lib/jline-4.2.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```